### PR TITLE
docker-compose.yml: add `restart: unless-stopped`

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.9"
 services:
   web:
     image: ghcr.io/postalserver/postal:{{version}}
+    restart: unless-stopped
     command: postal web-server
     network_mode: host
     volumes:
@@ -9,6 +10,7 @@ services:
 
   smtp:
     image: ghcr.io/postalserver/postal:{{version}}
+    restart: unless-stopped
     command: postal smtp-server
     network_mode: host
     cap_add:
@@ -18,6 +20,7 @@ services:
 
   worker:
     image: ghcr.io/postalserver/postal:{{version}}
+    restart: unless-stopped
     command: postal worker
     network_mode: host
     volumes:
@@ -25,6 +28,7 @@ services:
 
   cron:
     image: ghcr.io/postalserver/postal:{{version}}
+    restart: unless-stopped
     command: postal cron
     network_mode: host
     volumes:
@@ -32,6 +36,7 @@ services:
 
   requeuer:
     image: ghcr.io/postalserver/postal:{{version}}
+    restart: unless-stopped
     command: postal requeuer
     network_mode: host
     volumes:
@@ -40,6 +45,7 @@ services:
   runner:
     profiles: ["tools"]
     image: ghcr.io/postalserver/postal:{{version}}
+    restart: unless-stopped
     command: postal
     network_mode: host
     volumes:


### PR DESCRIPTION
Adding `restart: unless-stopped` to every docker-compose service.
With `restart: unless-stopped` the services' containers are restarted in case of failure or host machine reboot.

I think this is the correct default strategy for restarting the docker containers for the postal application.