### PR TITLE
update postal install script to set correct dns config

### DIFF
--- a/examples/postal.yml
+++ b/examples/postal.yml
@@ -48,12 +48,12 @@ dns:
   # https://github.com/atech/postal/wiki/Domains-&-DNS-Configuration for further
   # information about these.
   mx_records:
-    - mx.postal.example.com
-  smtp_server_hostname: postal.example.com
-  spf_include: spf.postal.example.com
-  return_path: rp.postal.example.com
-  route_domain: routes.postal.example.com
-  track_domain: track.postal.example.com
+    - mx.postal.yourdomain.com
+  smtp_server_hostname: postal.yourdomain.com
+  spf_include: spf.postal.yourdomain.com
+  return_path: rp.postal.yourdomain.com
+  route_domain: routes.postal.yourdomain.com
+  track_domain: track.postal.yourdomain.com
 
 smtp:
   # Specify an SMTP server that can be used to send messages from the Postal management


### PR DESCRIPTION
Install script and docs have mixed use of `postal.yourdomain.com` and `postal.example.com`. This causes a configuration issue on initial setup. The install script takes in a hostname, copies the `examples/postal.yml`, and then uses `sed` to update some placeholders in that the file with the user-specified domain name. 

`examples/postal.yml` has placehoders of `postal.example.com`, but the script replaces occurences of `postal.yourdomain.com` which do not actually occur in that file. As a result, a setup that uses the documentation will still have all the DNS settings still pointing to `postal.example.com`. 

The impact of this is that the in-app instructions to setup DNS are incorrect. E.g. the app will tell me to create a TXT record like `v=spf1 a mx include:spf.postal.burnerlogin.com ~all` which of course is not correct. It also appears that the DNS checker will test against the wrong domain

I update the example postal.yml to match the script, so the placeholders are replaced as expected.