### PR TITLE
Add 'restart: always' to Docker Compose file so that Postal starts on boot

### DIFF
--- a/templates/docker-compose.yml
+++ b/templates/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: ghcr.io/postalserver/postal:{{version}}
     command: postal web-server
     network_mode: host
+    restart: always
     volumes:
       - /opt/postal/config:/config
 
@@ -11,6 +12,7 @@ services:
     image: ghcr.io/postalserver/postal:{{version}}
     command: postal smtp-server
     network_mode: host
+    restart: always
     cap_add:
       - NET_BIND_SERVICE
     volumes:
@@ -20,6 +22,7 @@ services:
     image: ghcr.io/postalserver/postal:{{version}}
     command: postal worker
     network_mode: host
+    restart: always
     volumes:
       - /opt/postal/config:/config
 
@@ -27,6 +30,7 @@ services:
     image: ghcr.io/postalserver/postal:{{version}}
     command: postal cron
     network_mode: host
+    restart: always
     volumes:
       - /opt/postal/config:/config
 
@@ -34,6 +38,7 @@ services:
     image: ghcr.io/postalserver/postal:{{version}}
     command: postal requeuer
     network_mode: host
+    restart: always
     volumes:
       - /opt/postal/config:/config
 
@@ -42,6 +47,7 @@ services:
     image: ghcr.io/postalserver/postal:{{version}}
     command: postal
     network_mode: host
+    restart: always
     volumes:
       - /opt/postal/config:/config
 


### PR DESCRIPTION
In almost all cases, Postal should start on boot. This commit avoids users from having to think of their own solutions (see https://github.com/postalserver/postal/issues/28 and https://github.com/postalserver/postal/issues/125).

If the comment https://github.com/postalserver/postal/issues/1984#issuecomment-1122299893 is still true, then at least it would be useful to add the most common way to achieve this to the documentation.