### PR TITLE
Fix typo in bin/postal command help text.

### DIFF
--- a/bin/postal
+++ b/bin/postal
@@ -216,7 +216,7 @@ case "$1" in
         echo
         echo -e " * \e[35mstart\e[0m - start Postal"
         echo -e " * \e[35mstop\e[0m - stop Postal"
-        echo -e " * \e[35mrestop\e[0m - restart Postal"
+        echo -e " * \e[35mrestart\e[0m - restart Postal"
         echo -e " * \e[35mstatus\e[0m - view current process status"
         echo -e " * \e[35mlogs [service]\e[0m - view logs from services"
         echo


### PR DESCRIPTION
There is a typo in the help infotext of the postal bin file. 