### PR TITLE
fix: add `version` command

### DIFF
--- a/bin/postal
+++ b/bin/postal
@@ -255,6 +255,10 @@ case "$1" in
         run-docker-compose "run --rm runner postal console"
         ;;
 
+    version)
+        run-docker-compose "run --rm runner postal version"
+        ;;
+
     make-user)
         run-docker-compose "run --rm runner postal make-user"
         ;;


### PR DESCRIPTION
The `postal --help` command has a `version` tool, but it's not working. This commit add this command.