### PR TITLE
feat: allow multiple Postal instances to run on the same host

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 config/**/*
 /docker-compose.*
 worker-replicas
+docker-project-name
+config-dir-path
 hooks/**/*

--- a/bin/postal
+++ b/bin/postal
@@ -7,6 +7,8 @@ ROOT_DIR=$( cd "$( dirname "${ORIGINAL_SCRIPT}" )/.." && pwd )
 DEV_MODE="false"
 GIT_PULL="true"
 FORCE_VERSION=""
+DEFAULT_DOCKER_PROJECT_NAME="postal"
+DEFAULT_CONFIG_DIR_PATH="/opt/postal/config"
 
 if command -v gsed &> /dev/null
 then
@@ -66,11 +68,13 @@ run-docker-compose() {
         set-postal-version $latest_version
     fi
 
+    local docker_project_name=`get-docker-project-name`
+
     if command -v docker-compose &> /dev/null
     then
-        run "docker-compose -p postal $@"
+        run "docker-compose -p $docker_project_name $@"
     else
-        run "docker compose -p postal $@"
+        run "docker compose -p $docker_project_name $@"
     fi
 }
 
@@ -102,6 +106,11 @@ set-postal-version() {
         worker_replicas=1
     fi
 
+    # Replace the config directory path
+    local config_dir_path=$(get-config-dir-path)
+    local escaped_config_dir_path=$(escape-sed-chars "$config_dir_path")
+    $SED -i "s/{{config-dir}}/$escaped_config_dir_path/" docker-compose.yml
+
     # Replace the worker counter
     $SED -i "s/{{worker-replicas}}/$worker_replicas/" docker-compose.yml
 
@@ -109,6 +118,34 @@ set-postal-version() {
     $SED -i "s/{{version}}/$desired_version/" docker-compose.yml
 
     call-hook "set-postal-version"
+}
+
+escape-sed-chars() {
+    local input="$1"
+
+    echo "$input" | $SED -e 's/[]\/$*.^|[]/\\&/g'
+}
+
+get-docker-project-name() {
+    if [ -f "docker-project-name" ]
+    then
+        local docker_project_name=$(cat docker-project-name | tr -d " \n")
+    else
+        local docker_project_name=$DEFAULT_DOCKER_PROJECT_NAME
+    fi
+
+    echo $docker_project_name
+}
+
+get-config-dir-path() {
+    if [ -f "config-dir-path" ]
+    then
+        local config_dir=$(cat config-dir-path | tr -d " \n")
+    else
+        local config_dir=$DEFAULT_CONFIG_DIR_PATH
+    fi
+
+    echo $config_dir
 }
 
 get-latest-postal-version() {
@@ -273,15 +310,20 @@ case "$1" in
 
         call-hook "pre-bootstrap"
 
-        if [ "$output_path" == "" ]; then
-            output_path=/opt/postal/config
-        fi
-
         if [ "$hostname" == "" ]; then
             echo 'hostname is missing.'
             echo
             echo 'usage: ./bin/postal postal.mydomain.com [path/to/config]'
             exit 1
+        fi
+
+        if [ "$output_path" == "" ]; then
+            output_path=$DEFAULT_CONFIG_DIR_PATH
+        fi
+
+        # Write the output path if it's not the default
+        if [ ! $output_path == $DEFAULT_CONFIG_DIR_PATH ]; then
+            echo $output_path > config-dir-path
         fi
 
         # Get the latest verison of Postal as the starting version for a

--- a/templates/docker-compose.v2.yml
+++ b/templates/docker-compose.v2.yml
@@ -5,7 +5,7 @@ services:
     command: postal web-server
     network_mode: host
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"
     restart: unless-stopped
 
   smtp:
@@ -15,7 +15,7 @@ services:
     cap_add:
       - NET_BIND_SERVICE
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"
     restart: unless-stopped
 
   worker:
@@ -23,7 +23,7 @@ services:
     command: postal worker
     network_mode: host
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"
     restart: unless-stopped
 
   cron:
@@ -31,7 +31,7 @@ services:
     command: postal cron
     network_mode: host
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"
     restart: unless-stopped
 
   requeuer:
@@ -39,7 +39,7 @@ services:
     command: postal requeuer
     network_mode: host
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"
     restart: unless-stopped
 
   runner:
@@ -48,4 +48,4 @@ services:
     command: postal
     network_mode: host
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"

--- a/templates/docker-compose.v3.yml
+++ b/templates/docker-compose.v3.yml
@@ -5,7 +5,7 @@ services:
     command: postal web-server
     network_mode: host
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"
     restart: unless-stopped
 
   smtp:
@@ -15,7 +15,7 @@ services:
     cap_add:
       - NET_BIND_SERVICE
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"
     restart: unless-stopped
 
   worker:
@@ -23,7 +23,7 @@ services:
     command: postal worker
     network_mode: host
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"
     restart: unless-stopped
 
   runner:
@@ -32,4 +32,4 @@ services:
     command: postal
     network_mode: host
     volumes:
-      - /opt/postal/config:/config
+      - "{{config-dir}}:/config"


### PR DESCRIPTION
This pull request adds support for running multiple Postal instances on the same machine. Each install would have its own install and config directories, and it would be recommended that each instance have a unique Postal symlink.

```
git clone https://github.com/postalserver/install /opt/postal-test/install
sudo ln -s /opt/postal-test/install/bin/postal /usr/bin/postal-test

# Set the unique project name
echo postal-test > /opt/postal-test/install/docker-project-name

# Bootstrap
postal-test bootstrap postal.example.com /opt/postal-test/config
```