### PR TITLE
fix: removed obsolete `version` attribute from docker-compose.yml

### DIFF
--- a/templates/docker-compose.v3.yml
+++ b/templates/docker-compose.v3.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   web:
     image: ghcr.io/postalserver/postal:{{version}}


### PR DESCRIPTION
- The `version` field in docker-compose.yml is no longer required and causes a warning.
- Removed the `version` attribute to avoid confusion and ensure compatibility with newer Docker Compose versions.