### PR TITLE
chore: remove the version top level element from docker-compose.yml

### DIFF
--- a/templates/docker-compose.v2.yml
+++ b/templates/docker-compose.v2.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   web:
     image: ghcr.io/postalserver/postal:{{version}}

--- a/templates/docker-compose.v3.yml
+++ b/templates/docker-compose.v3.yml
@@ -1,4 +1,3 @@
-version: "3.9"
 services:
   web:
     image: ghcr.io/postalserver/postal:{{version}}


### PR DESCRIPTION
According to the [official Docker Compose documentation](https://docs.docker.com/reference/compose-file/version-and-name/), the version setting is now obsolete, which will trigger related warnings when running the docker compose command.